### PR TITLE
Header combine

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 hiimtmac
+Copyright (c) 2019 hiimtmac
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/SwiftyGraphQL.podspec
+++ b/SwiftyGraphQL.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
     
     s.name                    = "SwiftyGraphQL"
-    s.version                 = "0.6.0"
+    s.version                 = "0.7.0"
     s.summary                 = "Typesafe(er) helpers for creating graphql queries & mutations"
     s.description             = <<-DESC
                                 This small library helps to create typesafe(er) mutations & queries for use with graphql.
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     s.author                  = "Taylor McIntyre"
     s.social_media_url        = "http://twitter.com/hiimtmac"
     s.ios.deployment_target   = "11.0"
-    s.swift_version           = "5.0"
+    s.swift_version           = "5.1"
     
     s.source                  = { :git => "https://github.com/hiimtmac/SwiftyGraphQL.git", :tag => "#{s.version}" }
     s.source_files            = "SwiftyGraphQL/**/*.{swift}"

--- a/SwiftyGraphQL.xcodeproj/project.pbxproj
+++ b/SwiftyGraphQL.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		D798D14A22569C100095DF8E /* VariableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D798D14922569C100095DF8E /* VariableTests.swift */; };
 		D7C7A4C5225788E1001BF4AD /* JSONEncoder+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C7A4C4225788E1001BF4AD /* JSONEncoder+Extensions.swift */; };
 		D7C7A4C822578DCA001BF4AD /* Encodable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C7A4C722578DCA001BF4AD /* Encodable+Extensions.swift */; };
+		D7DA3DDD23465FCD00C098E8 /* Parameterable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7DA3DDC23465FCD00C098E8 /* Parameterable.swift */; };
 		D7E5B2C5216CE52F004CA6C4 /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7E5B2C4216CE52F004CA6C4 /* Response.swift */; };
 		D7E5B2C7216CEC0B004CA6C4 /* NodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7E5B2C6216CEC0B004CA6C4 /* NodeTests.swift */; };
 		D7E5B2C9216CEC13004CA6C4 /* FragmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7E5B2C8216CEC13004CA6C4 /* FragmentTests.swift */; };
@@ -71,6 +72,7 @@
 		D798D14922569C100095DF8E /* VariableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariableTests.swift; sourceTree = "<group>"; };
 		D7C7A4C4225788E1001BF4AD /* JSONEncoder+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONEncoder+Extensions.swift"; sourceTree = "<group>"; };
 		D7C7A4C722578DCA001BF4AD /* Encodable+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+Extensions.swift"; sourceTree = "<group>"; };
+		D7DA3DDC23465FCD00C098E8 /* Parameterable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parameterable.swift; sourceTree = "<group>"; };
 		D7E5B2C4216CE52F004CA6C4 /* Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
 		D7E5B2C6216CEC0B004CA6C4 /* NodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeTests.swift; sourceTree = "<group>"; };
 		D7E5B2C8216CEC13004CA6C4 /* FragmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FragmentTests.swift; sourceTree = "<group>"; };
@@ -228,6 +230,7 @@
 			children = (
 				D7FE5C9D2256EF3F00B0EEE3 /* ParameterRepresentable.swift */,
 				D7ED5DD621811450005E5CDB /* Parameters.swift */,
+				D7DA3DDC23465FCD00C098E8 /* Parameterable.swift */,
 			);
 			path = Parameters;
 			sourceTree = "<group>";
@@ -351,6 +354,7 @@
 				D7F588C52180CEE800BDD411 /* Error.swift in Sources */,
 				D776D329224EB39100460389 /* Request.swift in Sources */,
 				D7ED5DD721811450005E5CDB /* Parameters.swift in Sources */,
+				D7DA3DDD23465FCD00C098E8 /* Parameterable.swift in Sources */,
 				D798D13322564F9D0095DF8E /* Variables.swift in Sources */,
 				D776D32D224EBD3600460389 /* StateMachine.swift in Sources */,
 				D724F92C216C9FA000342F5A /* FragmentRepresentable.swift in Sources */,

--- a/SwiftyGraphQL.xcodeproj/project.pbxproj
+++ b/SwiftyGraphQL.xcodeproj/project.pbxproj
@@ -534,6 +534,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 0.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hiimtmac.SwiftyGraphQL;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -561,6 +562,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 0.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hiimtmac.SwiftyGraphQL;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/SwiftyGraphQL.xcodeproj/xcshareddata/xcschemes/SwiftyGraphQL.xcscheme
+++ b/SwiftyGraphQL.xcodeproj/xcshareddata/xcschemes/SwiftyGraphQL.xcscheme
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D724F90E216C9F9000342F5A"
+               BuildableName = "SwiftyGraphQL.framework"
+               BlueprintName = "SwiftyGraphQL"
+               ReferencedContainer = "container:SwiftyGraphQL.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D724F917216C9F9000342F5A"
+               BuildableName = "SwiftyGraphQLTests.xctest"
+               BlueprintName = "SwiftyGraphQLTests"
+               ReferencedContainer = "container:SwiftyGraphQL.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D724F90E216C9F9000342F5A"
+            BuildableName = "SwiftyGraphQL.framework"
+            BlueprintName = "SwiftyGraphQL"
+            ReferencedContainer = "container:SwiftyGraphQL.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D724F90E216C9F9000342F5A"
+            BuildableName = "SwiftyGraphQL.framework"
+            BlueprintName = "SwiftyGraphQL"
+            ReferencedContainer = "container:SwiftyGraphQL.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D724F90E216C9F9000342F5A"
+            BuildableName = "SwiftyGraphQL.framework"
+            BlueprintName = "SwiftyGraphQL"
+            ReferencedContainer = "container:SwiftyGraphQL.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SwiftyGraphQL.xcodeproj/xcuserdata/taylormcintyre.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/SwiftyGraphQL.xcodeproj/xcuserdata/taylormcintyre.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -15,5 +15,18 @@
 			<integer>0</integer>
 		</dict>
 	</dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>D724F90E216C9F9000342F5A</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>D724F917216C9F9000342F5A</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/SwiftyGraphQL/Info.plist
+++ b/SwiftyGraphQL/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/SwiftyGraphQL/Parameters/Parameterable.swift
+++ b/SwiftyGraphQL/Parameters/Parameterable.swift
@@ -1,0 +1,13 @@
+//
+//  Parameterable.swift
+//  SwiftyGraphQL
+//
+//  Created by Taylor McIntyre on 2019-10-03.
+//  Copyright © 2019 hiimtmac. All rights reserved.
+//
+
+import Foundation
+
+public protocol GraphQLParameterable {
+    func graphQLParameterEncode() -> GraphQLParameters
+}

--- a/SwiftyGraphQL/Parameters/Parameters.swift
+++ b/SwiftyGraphQL/Parameters/Parameters.swift
@@ -8,6 +8,10 @@
 
 import Foundation
 
+public protocol GraphQLParameterable {
+    func graphQLParameterEncode() -> GraphQLParameters
+}
+
 public struct GraphQLParameters {
     var parameters: [String: GraphQLParameterRepresentable?]
     
@@ -26,13 +30,13 @@ public struct GraphQLParameters {
     }
     
     public static func +(lhs: GraphQLParameters, rhs: GraphQLParameters) -> GraphQLParameters {
-        let contents = lhs.parameters.merging(rhs.parameters) { (_, new) in new }
+        let contents = lhs.parameters.merging(rhs.parameters) { $1 }
         return GraphQLParameters(contents)
     }
     
     public mutating func set(_ parameters: [String: GraphQLParameterRepresentable?]) {
-        for parameter in parameters {
-            self.set(key: parameter.key, value: parameter.value)
+        parameters.forEach {
+            self.set(key: $0.key, value: $0.value)
         }
     }
     

--- a/SwiftyGraphQL/Parameters/Parameters.swift
+++ b/SwiftyGraphQL/Parameters/Parameters.swift
@@ -8,10 +8,6 @@
 
 import Foundation
 
-public protocol GraphQLParameterable {
-    func graphQLParameterEncode() -> GraphQLParameters
-}
-
 public struct GraphQLParameters {
     var parameters: [String: GraphQLParameterRepresentable?]
     

--- a/SwiftyGraphQL/Requests/Request.swift
+++ b/SwiftyGraphQL/Requests/Request.swift
@@ -11,30 +11,42 @@ import Foundation
 public protocol GraphQLRequest {
     associatedtype GraphQLReturn: Decodable
     var query: GraphQLQuery { get set }
-    var headers: [String: String]? { get set }
+    var requestHeaders: [String: String?]? { get set }
 }
 
 extension GraphQLRequest {
-    public func urlRequest(headers: [String: String]? = nil, encoder: JSONEncoder? = nil) throws -> URLRequest {
+    public func urlRequest(headers flightHeaders: [String: String?]? = nil, encoder: JSONEncoder? = nil) throws -> URLRequest {
         let encoder = encoder ?? SwiftyGraphQL.shared.queryEncoder ?? JSONEncoder()
         
         guard let url = SwiftyGraphQL.shared.graphQLEndpoint else {
-            fatalError("No url configured")
+            fatalError("No url configured, please set `SwiftyGraphQL.shared.graphQLEndpoint`")
         }
         
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.httpBody = try encoder.encode(query)
         
-        for header in headers ?? self.headers ?? [:] {
-            request.setValue(header.value, forHTTPHeaderField: header.key)
-        }
+        let dHeaders = SwiftyGraphQL.shared.defaultHeaders ?? [:]
+        let rHeaders = requestHeaders ?? [:]
+        let fHeaders = flightHeaders ?? [:]
         
+        (dHeaders + rHeaders + fHeaders).forEach {
+            if let value = $0.value {
+                request.setValue(value, forHTTPHeaderField: $0.key)
+            }
+        }
+
         return request
     }
     
     public func decode(data: Data, decoder: JSONDecoder? = nil) throws -> GraphQLResponse<GraphQLReturn> {
         let decoder = decoder ?? SwiftyGraphQL.shared.responseDecoder ?? JSONDecoder()
         return try decoder.graphQLDecode(GraphQLResponse<GraphQLReturn>.self, from: data)
+    }
+}
+
+extension Dictionary where Key == String, Value == String? {
+    static func +(lhs: Self, rhs: Self) -> Self {
+        return lhs.merging(rhs) { $1 }
     }
 }

--- a/SwiftyGraphQL/Requests/StateMachine.swift
+++ b/SwiftyGraphQL/Requests/StateMachine.swift
@@ -15,4 +15,5 @@ public class SwiftyGraphQL {
     public var graphQLEndpoint: URL!
     public var queryEncoder: JSONEncoder?
     public var responseDecoder: JSONDecoder?
+    public var defaultHeaders: [String: String?]?
 }

--- a/SwiftyGraphQLTests/ParameterTests.swift
+++ b/SwiftyGraphQLTests/ParameterTests.swift
@@ -159,4 +159,24 @@ class ParameterTests: XCTestCase {
         let compare = #"(age: 12.5, name: "taylor", since: 20)"#
         XCTAssertEqual(parameters.statement, compare)
     }
+    
+    func testGraphQLParameterable() {
+        struct Test: GraphQLParameterable {
+            let int: Int
+            let string: String
+            let bool: Bool
+            
+            func graphQLParameterEncode() -> GraphQLParameters {
+                return GraphQLParameters([
+                    "int": int,
+                    "string": string,
+                    "bool": bool
+                ])
+            }
+        }
+        
+        let parameters = Test(int: 20, string: "taylor", bool: true).graphQLParameterEncode()
+        let compare = #"(bool: true, int: 20, string: "taylor")"#
+        XCTAssertEqual(parameters.statement, compare)
+    }
 }


### PR DESCRIPTION
- Headers can be built up from the general config (all requests), to on the request type (single type of request), to pre flight changes (to that instance of request type). Setting a header to `nil` at any stage will override/remove it
- New `GraphQLParameterable` protocol to help with generating graphql parameters from objects