### PR TITLE
Plugins Arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,10 +356,11 @@ public struct GraphQLRequest<T: Decodable> {
     public let query: GraphQLQuery
     public var headers: HTTPHeaders
     public var encoder: JSONEncoder?
+    public var encodePlugins: [(inout URLRequest) -> Void]
     public var decoder: JSONDecoder?
     
-    public func urlRequest(headers: HTTPHeaders = .init(), encoder: JSONEncoder? = nil) throws -> URLRequest { ... }
-    public func decode(data: Data, decoder: JSONDecoder? = nil) throws -> GraphQLResponse<T> { ... }
+    public func urlRequest() throws -> URLRequest { ... }
+    public func decode(data: Data) throws -> GraphQLResponse<T> { ... }
 }
 ```
 
@@ -382,8 +383,8 @@ extension JSONDecoder {
 }
 
 extension GraphQLRequest {
-    public func decode(data: Data, decoder: JSONDecoder? = nil) throws -> GraphQLResponse<T> {
-        let decoder = decoder ?? self.decoder ?? SwiftyGraphQL.shared.responseDecoder
+    public func decode(data: Data) throws -> GraphQLResponse<T> {
+        let decoder = self.decoder ?? SwiftyGraphQL.shared.responseDecoder
         return try decoder.graphQLDecode(GraphQLResponse<T>.self, from: data)
     }
 }

--- a/SwiftyGraphQL.podspec
+++ b/SwiftyGraphQL.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
     
     s.name                    = "SwiftyGraphQL"
-    s.version                 = "0.9.3"
+    s.version                 = "0.10.0"
     s.summary                 = "Typesafe(er) helpers for creating graphql queries & mutations"
     s.description             = <<-DESC
                                 This small library helps to create typesafe(er) mutations & queries for use with graphql.

--- a/SwiftyGraphQL.xcodeproj/project.pbxproj
+++ b/SwiftyGraphQL.xcodeproj/project.pbxproj
@@ -567,7 +567,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.9.3;
+				MARKETING_VERSION = 0.10.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hiimtmac.SwiftyGraphQL;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -596,7 +596,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.9.3;
+				MARKETING_VERSION = 0.10.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hiimtmac.SwiftyGraphQL;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/SwiftyGraphQLTests/Helpers/Network.swift
+++ b/SwiftyGraphQLTests/Helpers/Network.swift
@@ -23,12 +23,9 @@ class MockNetwork {
     }
     
     func perform<T>(request: GraphQLRequest<T>,
-                    headers: HTTPHeaders = .init(),
-                    encoder: JSONEncoder? = nil,
-                    decoder: JSONDecoder? = nil,
                     completion: @escaping (Result<GraphQLResponse<T>, Error>) -> Void) {
         
-        guard let urlRequest = try? request.urlRequest(headers: headers, encoder: encoder) else {
+        guard let urlRequest = try? request.urlRequest() else {
             completion(.failure(MockError.noURL))
             return
         }
@@ -39,7 +36,7 @@ class MockNetwork {
                 return
             }
             
-            guard let decoded = try? request.decode(data: data, decoder: decoder) else {
+            guard let decoded = try? request.decode(data: data) else {
                 completion(Result.failure(MockError.decodeError))
                 return
             }

--- a/SwiftyGraphQLTests/RequestTests.swift
+++ b/SwiftyGraphQLTests/RequestTests.swift
@@ -65,18 +65,23 @@ class RequestTests: XCTestCase {
             .init(name: .init("five"), value: "asdasd"),
             .init(name: .init("five"), value: "default")
         ])
-        let request = GraphQLRequest<String>(query: query, headers: HTTPHeaders([
+        var request = GraphQLRequest<String>(query: query, headers: HTTPHeaders([
             .init(name: .init("one"), value: "nil"),
             .init(name: .init("two"), value: "request"),
             .init(name: .init("three"), value: "request"),
             .init(name: .init("four"), value: "request"),
             .init(name: .init("six"), value: "request")
         ]))
-        let urlRequest = try request.urlRequest(headers: HTTPHeaders([
-            .init(name: .init("three"), value: "flight"),
-            .init(name: .init("four"), value: "nil"),
-            .init(name: .init("seven"), value: "flight")
-        ]))
+        request.addEncodePlugin { request in
+            HTTPHeaders([
+                .init(name: .init("three"), value: "flight"),
+                .init(name: .init("four"), value: "nil"),
+                .init(name: .init("seven"), value: "flight")
+            ]).headers.forEach {
+                request.setValue($0.value, forHTTPHeaderField: $0.key.name)
+            }
+        }
+        let urlRequest = try request.urlRequest()
         
         XCTAssertEqual(urlRequest.allHTTPHeaderFields?["one"], "nil")
         XCTAssertEqual(urlRequest.allHTTPHeaderFields?["two"], "request")
@@ -129,7 +134,9 @@ class RequestTests: XCTestCase {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         
-        network.perform(request: request, decoder: decoder) { result in
+        request.decoder = decoder
+        
+        network.perform(request: request) { result in
             switch result {
             case .success(let decoded):
                 XCTAssertEqual(decoded.data.address, "place")
@@ -184,5 +191,30 @@ class RequestTests: XCTestCase {
         XCTAssertEqual(combine[.accept], "application/json; charset=utf-8")
         XCTAssertEqual(combine[.contentEncoding], "text/plain; charset=utf-8")
         XCTAssertEqual(combine[.contentType], "application/json; charset=utf-8")
+    }
+    
+    func testRequestPlugins() throws {
+        let query = GraphQLQuery(query: GraphQLNode.node(name: "hi", [.attribute("hi")]))
+        var request = GraphQLRequest<String>(query: query)
+        let urlReq = try request.urlRequest()
+        XCTAssertEqual(urlReq.cachePolicy.rawValue, URLRequest.CachePolicy.useProtocolCachePolicy.rawValue)
+        XCTAssertEqual(urlReq.timeoutInterval, 60)
+        XCTAssertEqual(urlReq.httpMethod, "POST")
+        
+        request.encodePlugins = [
+            { $0.cachePolicy = URLRequest.CachePolicy.reloadIgnoringCacheData },
+            { $0.httpMethod = "GET" }
+        ]
+        
+        let one = try request.urlRequest()
+        XCTAssertEqual(one.cachePolicy.rawValue, URLRequest.CachePolicy.reloadIgnoringCacheData.rawValue)
+        XCTAssertEqual(one.httpMethod, "GET")
+        
+        request.addEncodePlugin { $0.timeoutInterval = 50 }
+        request.addEncodePlugin { $0.httpMethod = "PUT" }
+        
+        let two = try request.urlRequest()
+        XCTAssertEqual(two.timeoutInterval, 50)
+        XCTAssertEqual(two.httpMethod, "PUT")
     }
 }

--- a/SwiftyGraphQLTests/RequestTests.swift
+++ b/SwiftyGraphQLTests/RequestTests.swift
@@ -75,18 +75,18 @@ class RequestTests: XCTestCase {
         request.addEncodePlugin { request in
             HTTPHeaders([
                 .init(name: .init("three"), value: "flight"),
-                .init(name: .init("four"), value: "nil"),
                 .init(name: .init("seven"), value: "flight")
             ]).headers.forEach {
                 request.setValue($0.value, forHTTPHeaderField: $0.key.name)
             }
+            request.setValue(nil, forHTTPHeaderField: "four")
         }
         let urlRequest = try request.urlRequest()
         
         XCTAssertEqual(urlRequest.allHTTPHeaderFields?["one"], "nil")
         XCTAssertEqual(urlRequest.allHTTPHeaderFields?["two"], "request")
         XCTAssertEqual(urlRequest.allHTTPHeaderFields?["three"], "flight")
-        XCTAssertEqual(urlRequest.allHTTPHeaderFields?["four"], "nil")
+        XCTAssertEqual(urlRequest.allHTTPHeaderFields?["four"], nil)
         XCTAssertEqual(urlRequest.allHTTPHeaderFields?["five"], "default")
         XCTAssertEqual(urlRequest.allHTTPHeaderFields?["six"], "request")
         XCTAssertEqual(urlRequest.allHTTPHeaderFields?["seven"], "flight")


### PR DESCRIPTION
Plugin arch used for modifying single `URLRequest` rather than assigning params to encode function. This allows for more flexibility because any property of the URL request can be modified now.