### PR TITLE
GQLFragmentable Fix/Enhancement

### DIFF
--- a/Sources/SwiftyGraphQL/Fragment.swift
+++ b/Sources/SwiftyGraphQL/Fragment.swift
@@ -15,10 +15,16 @@ public protocol GQLFragmentable {
 }
 
 extension GQLFragmentable {
-    static var fragmentType: String { "\(Self.self)" }
-    static var fragmentName: String { fragmentType.lowercased() }
+    public static var fragmentType: String { "\(Self.self)" }
+    public static var fragmentName: String { fragmentType.lowercased() }
     static var fragmentString: String {
         return "fragment \(fragmentName) on \(fragmentType) { \(gqlContent.gqlQueryString) }"
+    }
+}
+
+extension GQLFragmentable where Self: GQLAttributable, CodingKeys: CaseIterable, CodingKeys.RawValue == String {
+    public static var gqlContent: GraphQL {
+        GQLAttributes(Self.self)
     }
 }
 

--- a/SwiftyGraphQL.podspec
+++ b/SwiftyGraphQL.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
     
     s.name                    = "SwiftyGraphQL"
-    s.version                 = "1.1.0"
+    s.version                 = "1.2.0"
     s.summary                 = "Typesafe(er) helpers for creating graphql queries & mutations"
     s.description             = <<-DESC
                                 This small library helps to create typesafe(er) mutations & queries for use with graphql.

--- a/Tests/SwiftyGraphQLTests/AttributeTests.swift
+++ b/Tests/SwiftyGraphQLTests/AttributeTests.swift
@@ -48,9 +48,24 @@ class AttributeTests: XCTestCase {
         XCTAssertEqual(attributes.gqlQueryString, "hello there")
     }
     
+    func testDefaultImplementation() {
+        struct Object: GQLFragmentable, GQLAttributable {
+            enum CodingKeys: String, CodingKey, CaseIterable {
+                case one
+                case two
+                case three = "four"
+            }
+        }
+        
+        let fragment = GQLFragment(Object.self)
+        XCTAssertEqual(fragment.gqlQueryString, "...object")
+        XCTAssertEqual(fragment.gqlFragmentString, "fragment object on Object { four one two }")
+    }
+    
     static var allTests = [
         ("testStrings", testStrings),
         ("testCodedKey", testCodedKey),
-        ("testFullFrgment", testFullFrgment)
+        ("testFullFrgment", testFullFrgment),
+        ("testDefaultImplementation", testDefaultImplementation)
     ]
 }

--- a/Tests/SwiftyGraphQLTests/Helpers/Helpers.swift
+++ b/Tests/SwiftyGraphQLTests/Helpers/Helpers.swift
@@ -25,9 +25,6 @@ struct Frag1: GQLFragmentable, Codable, Equatable {
 }
 
 struct Frag2: GQLFragmentable, Codable, Equatable {
-    static let fragmentName = "frag2"
-    static let fragmentType = "Frag2"
-    
     let birthday: Date
     let address: String?
     


### PR DESCRIPTION
Fixed default type & name for fragmentable. Default content for fragment to use all attributes if attributable.

Default implementation of `fragmentName`/`fragmentType` was not public so it force you to implement on your types.