### PR TITLE
Add dictionary to argument variables

### DIFF
--- a/Sources/SwiftyGraphQL/Argument.swift
+++ b/Sources/SwiftyGraphQL/Argument.swift
@@ -40,25 +40,25 @@ extension String: GQLArgument {
 
 extension Int: GQLArgument {
     public var gqlArgumentValue: String {
-        return "\(self)"
+        "\(self)"
     }
 }
 
 extension Double: GQLArgument {
     public var gqlArgumentValue: String {
-        return "\(self)"
+        "\(self)"
     }
 }
 
 extension Float: GQLArgument {
     public var gqlArgumentValue: String {
-        return "\(self)"
+        "\(self)"
     }
 }
 
 extension Bool: GQLArgument {
     public var gqlArgumentValue: String {
-        return "\(self)"
+        "\(self)"
     }
 }
 

--- a/Sources/SwiftyGraphQL/Node.swift
+++ b/Sources/SwiftyGraphQL/Node.swift
@@ -103,6 +103,13 @@ extension GQLNode {
         return .init(name, alias: alias, arguments: copyArgs, directive: directive, content: content)
     }
     
+    public func withVariable(named: String, variables: [String: String]) -> Self {
+        var copyArgs = self.arguments
+        copyArgs[named] = ObjArg(variables)
+
+        return .init(name, alias: alias, arguments: copyArgs, directive: directive, content: content)
+    }
+    
     public func withVariables(_ variables: [String: String]) -> Self {
         var copyArgs = self.arguments
         variables.forEach { copyArgs[$0.key] = Arg(name: $0.value) }
@@ -119,6 +126,27 @@ extension GQLNode {
         
         init(name: String) {
             gqlArgumentValue = "$\(name)"
+        }
+    }
+    
+    private struct ObjArg: GQLArgument {
+        var gqlArgumentValue: String
+        
+        init(_ values: [String: String]) {
+            var value = "{"
+            let enumeration = values
+                .sorted { $0.key < $1.key }
+                .enumerated()
+            
+            for (i, v) in enumeration {
+                if i > 0 {
+                    value += ","
+                }
+                value += " \(v.key): $\(v.value)"
+            }
+            
+            value += " }"
+            gqlArgumentValue = value
         }
     }
 }

--- a/Tests/SwiftyGraphQLTests/HelpTests.swift
+++ b/Tests/SwiftyGraphQLTests/HelpTests.swift
@@ -1,0 +1,59 @@
+//
+//  File.swift
+//  
+//
+//  Created by Taylor McIntyre on 2020-09-29.
+//
+
+import XCTest
+@testable import SwiftyGraphQL
+
+class HelpTests: XCTestCase {
+    
+    // https://github.com/hiimtmac/SwiftyGraphQL/issues/26
+    func testHelp26() throws {
+        let usernameVar: GQLVariable = "tmac"
+        let slugVar: GQLVariable = "swifty-graphql"
+        
+        let query = GQLQuery("CodaPlayerItem") {
+            GQLNode("cloudcastLookup") {
+                "__typename"
+                "id"
+                GQLNode("streamInfo") {
+                    "__typename"
+                    "dashUrl"
+                    "hlsUrl"
+                    "url"
+                }
+                GQLNode("picture") {
+                    "__typename"
+                    "urlRoot"
+                }
+                "name"
+                GQLNode("owner") {
+                    "__typename"
+                    "displayName"
+                }
+            }
+            .withVariable(named: "lookup", variables: ["username": "username", "slug": "slug"])
+        }
+        .withVariables(["username": usernameVar, "slug": slugVar])
+        
+        struct Decode: Decodable {
+            let query: String
+            let variables: Variables
+            
+            struct Variables: Decodable {
+                let username: String
+                let slug: String
+            }
+        }
+        
+        XCTAssertEqual(query.gqlQueryWithFragments, #"query CodaPlayerItem($slug: String!, $username: String!) { cloudcastLookup(lookup: { slug: $slug, username: $username }) { __typename id name owner { __typename displayName } picture { __typename urlRoot } streamInfo { __typename dashUrl hlsUrl url } } }"#)
+        
+        let encoded = try JSONEncoder().encode(query)
+        let decoded = try JSONDecoder().decode(Decode.self, from: encoded)
+        XCTAssertEqual(decoded.variables.username, "tmac")
+        XCTAssertEqual(decoded.variables.slug, "swifty-graphql")
+    }
+}


### PR DESCRIPTION
Adds `.withVariable(named: "lookup", variables: ["username": "username", "slug": "slug"])` behaviour to `GQLNode`
which would render out `xxxxx(lookup: { slug: $slug, username: $username })`

Closes: #26 